### PR TITLE
Feature/allow control of other scripts (#1)

### DIFF
--- a/App Optimization/app-optimization.liquid
+++ b/App Optimization/app-optimization.liquid
@@ -420,12 +420,15 @@
           {%- for block in section.blocks -%}
             {%- unless urls contains block.settings.url -%}
               {%- liquid 
-                if block.settings[block_key] == true
-                  assign load = 'Block'
-                elsif block.settings[scroll_key] == true
-                  assign load = 'Scroll'
-                elsif block.settings[interaction_key] == true
-                  assign load = 'Interaction'
+                assign load='Default'
+                if block.settings.not_an_app
+                  if block.settings[block_key] == true
+                    assign load = 'Block'
+                  elsif block.settings[scroll_key] == true
+                    assign load = 'Scroll'
+                  elsif block.settings[interaction_key] == true
+                    assign load = 'Interaction'
+                  endif
                 endif
               -%}
               <tr>

--- a/App Optimization/app-optimization.liquid
+++ b/App Optimization/app-optimization.liquid
@@ -17,7 +17,7 @@
     if content_for_header contains url or block.settings.not_an_app
       assign header_checked = true
     else
-      assign header_checked = true
+      assign header_checked = false
     endif 
 
     if block.settings[block_key] == true and header_checked

--- a/App Optimization/app-optimization.liquid
+++ b/App Optimization/app-optimization.liquid
@@ -15,15 +15,15 @@
     assign url = block.settings.url | replace: '/', '\/'
     
     if content_for_header contains url or block.settings.not_an_app 
-      if block.settings[block_key] == true and header_checked
+      if block.settings[block_key] == true 
         assign arr_block = block | concat: arr_block
       endif
   
-      if block.settings[scroll_key] == true and header_checked
+      if block.settings[scroll_key] == true 
         assign arr_scroll = block | concat: arr_scroll
       endif
   
-      if block.settings[interaction_key] == true and header_checked
+      if block.settings[interaction_key] == true 
         assign arr_interaction = block | concat: arr_interaction
       endif
     endif 

--- a/App Optimization/app-optimization.liquid
+++ b/App Optimization/app-optimization.liquid
@@ -13,16 +13,22 @@
 
   for block in section.blocks
     assign url = block.settings.url | replace: '/', '\/'
+    
+    if content_for_header contains url or block.settings.not_an_app
+      assign header_checked = true
+    else
+      assign header_checked = true
+    endif 
 
-    if block.settings[block_key] == true and content_for_header contains url
+    if block.settings[block_key] == true and header_checked
       assign arr_block = block | concat: arr_block
     endif
 
-    if block.settings[scroll_key] == true and content_for_header contains url
+    if block.settings[scroll_key] == true and header_checked
       assign arr_scroll = block | concat: arr_scroll
     endif
 
-    if block.settings[interaction_key] == true and content_for_header contains url
+    if block.settings[interaction_key] == true and header_checked
       assign arr_interaction = block | concat: arr_interaction
     endif
   endfor
@@ -200,7 +206,8 @@
 {%- comment -%}
   The code below will be loaded only in the Theme Editor
 {%- endcomment-%}
-{%- assign urls = content_for_header | split: 'var urls =' | last | split: 'for (var i = 0' | first | remove: ';' | split: ',' -%}
+{%- assign urls = content_for_header | split: 'var urls =' | last | split: 'for (var i = 0' | first | remove: ';'  -%}
+{%- assign urls_array = urls | split: ',' -%}
 
 <template id="sd-app-list-template">
   <style>  
@@ -373,7 +380,7 @@
           </tr>
         </thead>
         <tbody>
-        {%- for url in urls -%}
+        {%- for url in urls_array -%}
           {%- liquid
             assign name = 'App name'
             assign load = 'Default'
@@ -411,6 +418,39 @@
             <td class="text-right"><p data-badge="{{ load }}">{{ load }}</p></td>
           </tr>
         {%- endfor -%}
+        {%- capture custom_scripts -%}
+          {%- assign urls = urls | replace: '\/', '/'  -%}            
+          {%- for block in section.blocks -%}
+            {%- unless urls contains block.settings.url -%}
+              {%- liquid 
+                if block.settings[block_key] == true
+                  assign load = 'Block'
+                elsif block.settings[scroll_key] == true
+                  assign load = 'Scroll'
+                elsif block.settings[interaction_key] == true
+                  assign load = 'Interaction'
+                endif
+              -%}
+              <tr>
+                <td><p>{{ block.settings.title }}</p></td>
+                <td>
+                  <p class="flex whitespace-no-wrap">
+                    {{ block.settings.url }}
+                  </p>
+                </td>
+                <td class="text-right"><p data-badge="{{ load }}">{{ load }}</p></td>
+              </tr>                     
+            {%- endunless -%}
+          {%- endfor -%}
+        {%- endcapture -%}
+        {%- unless custom_scripts == blank %}
+          <tr>
+            <td>
+              <h4 class="mb-4">Non-App scripts</h4>
+            </td>
+          </tr>
+          {{ custom_scripts }}
+        {% endunless %}
         </tbody>
       </table>
     </div>
@@ -516,6 +556,12 @@
             "label": "App ScriptTag URL",
             "placeholder": "e.g. shopifycdn.com/assets/v4/spr.js",
             "info": "Use partial URL, e.g: shopifycdn.com/assets/v4/spr.js"
+          },
+          {
+            "type": "checkbox",
+            "id":   "not_an_app",
+            "label":  "This is not a main App script",
+            "info":   "Allows control of scripts which are not direrctly loaded via Scrip Tags"
           },
           {
             "type": "header",

--- a/App Optimization/app-optimization.liquid
+++ b/App Optimization/app-optimization.liquid
@@ -14,23 +14,20 @@
   for block in section.blocks
     assign url = block.settings.url | replace: '/', '\/'
     
-    if content_for_header contains url or block.settings.not_an_app
-      assign header_checked = true
-    else
-      assign header_checked = false
+    if content_for_header contains url or block.settings.not_an_app 
+      if block.settings[block_key] == true and header_checked
+        assign arr_block = block | concat: arr_block
+      endif
+  
+      if block.settings[scroll_key] == true and header_checked
+        assign arr_scroll = block | concat: arr_scroll
+      endif
+  
+      if block.settings[interaction_key] == true and header_checked
+        assign arr_interaction = block | concat: arr_interaction
+      endif
     endif 
 
-    if block.settings[block_key] == true and header_checked
-      assign arr_block = block | concat: arr_block
-    endif
-
-    if block.settings[scroll_key] == true and header_checked
-      assign arr_scroll = block | concat: arr_scroll
-    endif
-
-    if block.settings[interaction_key] == true and header_checked
-      assign arr_interaction = block | concat: arr_interaction
-    endif
   endfor
 
   assign settings_data = arr_block | concat: arr_scroll | concat: arr_interaction | uniq | map: 'settings'


### PR DESCRIPTION
* Allow control of non-ScriptTag scripts
* Added display of non-Apps scripts

Added a checkbox to ignore whether the block URL is present in content_for_header.
This will allow delayed loading of non-scriptTag scripts.
For example, some URL loaded by App, or by another script, like Google Tag manager.

