### PR TITLE
Update app-optimization.liquid

### DIFF
--- a/App Optimization/app-optimization.liquid
+++ b/App Optimization/app-optimization.liquid
@@ -131,10 +131,12 @@
         var eventFn = partial(loadOnScroll, loadRule.originalUrl);
         var eventOptions = supportsPassive ? {passive: true} : false;
         window.addEventListener('scroll', eventFn, eventOptions);
+        window.addEventListener('mousemove', eventFn, eventOptions);
+        window.addEventListener('touchstart', eventFn, eventOptions);
 
         function loadOnScroll(src) {
           loadScript(src);
-          window.removeEventListener('scroll', eventFn, eventOptions);
+          window.removeEventListener(event.type, eventFn, eventOptions); 
         }
       }
 


### PR DESCRIPTION
Closes #9 

Adds extra listeners to allow for non-scrolling pages. `mousemove` and `touchstart` do pretty much what they say. This helps block elements until you are ready for them to appear. One change from my original issue is the combined `event.type` remove.  This cleanly removes the listeners all at once, otherwise you get three removal triggers which could cause scripts to try and load more than once.