### PR TITLE
CSS to fix layout breaking in case of long URLs

### DIFF
--- a/App Optimization/app-optimization.liquid
+++ b/App Optimization/app-optimization.liquid
@@ -235,6 +235,7 @@
     
     a {
       text-decoration: none;
+      white-space: break-spaces;
     }
     
     table {


### PR DESCRIPTION
Long URLs cause table cells to shrink, this fixes it by making the URLs break.

Before:
<img width="1183" alt="image" src="https://github.com/user-attachments/assets/46205f50-fe53-48d5-93d8-66494ed4dd95" />

After:
<img width="1149" alt="image" src="https://github.com/user-attachments/assets/266d7c46-9325-4a80-a0ee-9b68ea9c5333" />
